### PR TITLE
RSSI reading improvement

### DIFF
--- a/rx5808-pro-diversityGc9n/rx5808-pro-diversityGc9n.ino
+++ b/rx5808-pro-diversityGc9n/rx5808-pro-diversityGc9n.ino
@@ -1232,9 +1232,13 @@ uint16_t readRSSI(char receiver)
 #endif
     for (uint8_t i = 0; i < RSSI_READS; i++)
     {
+#ifdef USE_DIVERSITY
+        analogRead(rssiPinA);
+#endif        
         rssiA += analogRead(rssiPinA);//random(RSSI_MAX_VAL-200, RSSI_MAX_VAL);//
 
 #ifdef USE_DIVERSITY
+        analogRead(rssiPinB);
         rssiB += analogRead(rssiPinB);//random(RSSI_MAX_VAL-200, RSSI_MAX_VAL);//
 #endif
 

--- a/rx5808-pro-diversityGc9n/settings.h
+++ b/rx5808-pro-diversityGc9n/settings.h
@@ -106,7 +106,7 @@ SOFTWARE.
 
 #define led 13
 // number of analog rssi reads to average for the current check.
-#define RSSI_READS 50
+#define RSSI_READS 10
 // RSSI default raw range
 #define RSSI_MIN_VAL 90
 #define RSSI_MAX_VAL 220


### PR DESCRIPTION
An atmel can't process an analogread pinchange this fast, adding an extra discard analogRead gives better readings in less readings.

This article goes in depth in ADC reading and delay times for reliable reading:
https://www.quora.com/Why-is-a-little-delay-needed-after-analogRead-in-Arduino

You should try this out it's a simple change in your version too:
```
         analogRead(rssiPinA);
         rssiA += analogRead(rssiPinA);//random(RSSI_MAX_VAL-200, RSSI_MAX_VAL);//
         analogRead(rssiPinB);
         rssiB += analogRead(rssiPinB);//random(RSSI_MAX_VAL-200, RSSI_MAX_VAL);//
```
You will see before if you screw in one antenna (and vtx turned on on a distance) both receivers will have better rssi, after changing to this only the one antenna will have a better rssi as would make sense. The overall processing time is also lower, originally 50x2 analogRead's can be lowered to 10x4 analogRead's, and having a more reliable rssi reading will lower wrong switchovers on already degraded video when flying in harsh conditions.