### PR TITLE
Instant receiver switching

### DIFF
--- a/rx5808-pro-diversityGc9n/rx5808-pro-diversityGc9n.ino
+++ b/rx5808-pro-diversityGc9n/rx5808-pro-diversityGc9n.ino
@@ -1336,13 +1336,21 @@ void setReceiver(uint8_t receiver) {
 #ifdef USE_DIVERSITY
     if(receiver == useReceiverA)
     {
+        #ifdef USE_FAST_SWITCHING
+        PORTC = (PORTC & B11111101) | B00000001; //This turns off receiverB_led and turns on receiverA_led simultaniously, this does however breaks the adaptability of receiverA_led/receiverB_led in settings.h
+        #else
         digitalWrite(receiverB_led, LOW);
         digitalWrite(receiverA_led, HIGH);
+        #endif
     }
     else
     {
+        #ifdef USE_FAST_SWITCHING
+        PORTC = (PORTC & B11111110) | B00000010; //This turns off receiverA_led and turns on receiverB_led simultaniously
+        #else
         digitalWrite(receiverA_led, LOW);
         digitalWrite(receiverB_led, HIGH);
+        #endif
     }
 #else
     digitalWrite(receiverA_led, HIGH);

--- a/rx5808-pro-diversityGc9n/settings.h
+++ b/rx5808-pro-diversityGc9n/settings.h
@@ -68,6 +68,8 @@ SOFTWARE.
 
 // Receiver PINS
 #define receiverA_led A0
+//Feature fast switching breaks the changeability of receiverA_led and receiverB_led, only to be used when receiverA_led = A0 and receiverB_led = A1
+#define USE_FAST_SWITCHING
 #define rssiPinA A6
 
 #define useReceiverA 1


### PR DESCRIPTION
Port manipulation used for faster switching, to be enabled or disabled using feature toggle USE_FAST_SWITCHING.

Inspired and substantiated here:
https://github.com/sheaivey/rx5808-pro-diversity/pull/98